### PR TITLE
docs: 补充 ARTEX_LLM_BASE_URL 接入 Novita 的示例

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ CGO_ENABLED=0 go build -tags embedui -o artex ./cmd/artex
 **LLM**：`export ANTHROPIC_API_KEY=sk-...`（或 `OPENAI_API_KEY`），也可在 UI 的「LLM 配置」页填写。
 可选：`ARTEX_LLM_PROVIDER` / `ARTEX_LLM_MODEL` / `ARTEX_LLM_BASE_URL` / `ARTEX_LLM_PROXY`。
 
+`ARTEX_LLM_BASE_URL` 可指向任意 OpenAI 兼容端点，例如 [Novita](https://novita.ai/)：
+
+```bash
+export ARTEX_LLM_PROVIDER=openai
+export OPENAI_API_KEY=<NOVITA_API_KEY>
+export ARTEX_LLM_BASE_URL=https://api.novita.ai/openai/v1
+export ARTEX_LLM_MODEL=qwen/qwen3-coder-480b-a35b-instruct
+```
+
 **并发**：每个任务的 work agent 数在「系统设置」里配置（默认 3）。
 
 **常用参数**：`./artex -addr :8787 -proxy :8788`（`-addr` 前端+API，`-proxy` 流量录制代理）。


### PR DESCRIPTION

## Summary
- README 已有的 `ARTEX_LLM_BASE_URL` 支持任意 OpenAI 兼容端点，但没有具体示例
- 补一个指向 Novita（`https://api.novita.ai/openai/v1`）的最小配置示例，方便用户直接照抄

## Changes
- `README.md`：在「LLM」配置段落下新增一段环境变量示例（`ARTEX_LLM_PROVIDER` / `OPENAI_API_KEY` / `ARTEX_LLM_BASE_URL` / `ARTEX_LLM_MODEL`）

## Verification
- 用真实 Novita API key 走仓库自身的 `agent.ConfigFrom` → `TestConnection` 代码路径验证：`openai` format + `https://api.novita.ai/openai/v1` + `qwen/qwen3-coder-480b-a35b-instruct`，连接成功
- `go test ./...` 通过
- 仅改动 `README.md`，不涉及代码逻辑
