### PR TITLE
fix(test): capture_usage 遵守迭代器协议,消除 yield 告警

### DIFF
--- a/agent/capture_usage_test.go
+++ b/agent/capture_usage_test.go
@@ -22,9 +22,16 @@ func (p captureUsageProvider) Stream(ctx context.Context, _ llm.CompletionReques
 func TestCaptureRunPersistsUsageOnProviderFailure(t *testing.T) {
 	wantErr := errors.New("provider failed after reporting usage")
 	provider := captureUsageProvider{stream: func(_ context.Context, yield func(llm.StreamEvent, error) bool) {
-		yield(llm.StreamEvent{Type: llm.SEMessageStart, Usage: llm.Usage{InputTokens: 11, CacheReadTokens: 3}}, nil)
-		yield(llm.StreamEvent{Type: llm.SETextDelta, Text: "partial"}, nil)
-		yield(llm.StreamEvent{Type: llm.SEMessageDelta, Usage: llm.Usage{OutputTokens: 7, CacheWriteTokens: 2}}, nil)
+		// 遵守迭代器协议:yield 返回 false 后立即停止,不再调用它。
+		if !yield(llm.StreamEvent{Type: llm.SEMessageStart, Usage: llm.Usage{InputTokens: 11, CacheReadTokens: 3}}, nil) {
+			return
+		}
+		if !yield(llm.StreamEvent{Type: llm.SETextDelta, Text: "partial"}, nil) {
+			return
+		}
+		if !yield(llm.StreamEvent{Type: llm.SEMessageDelta, Usage: llm.Usage{OutputTokens: 7, CacheWriteTokens: 2}}, nil) {
+			return
+		}
 		yield(llm.StreamEvent{}, wantErr)
 	}}
 
@@ -41,9 +48,16 @@ func TestCaptureRunPersistsUsageOnProviderFailure(t *testing.T) {
 func TestCaptureRunPersistsUsageOnCancellation(t *testing.T) {
 	started := make(chan struct{})
 	provider := captureUsageProvider{stream: func(ctx context.Context, yield func(llm.StreamEvent, error) bool) {
-		yield(llm.StreamEvent{Type: llm.SEMessageStart, Usage: llm.Usage{InputTokens: 13, CacheReadTokens: 5}}, nil)
-		yield(llm.StreamEvent{Type: llm.SETextDelta, Text: "partial"}, nil)
-		yield(llm.StreamEvent{Type: llm.SEMessageDelta, Usage: llm.Usage{OutputTokens: 9, CacheWriteTokens: 4}}, nil)
+		// 遵守迭代器协议:yield 返回 false 后立即停止,不再调用它。
+		if !yield(llm.StreamEvent{Type: llm.SEMessageStart, Usage: llm.Usage{InputTokens: 13, CacheReadTokens: 5}}, nil) {
+			return
+		}
+		if !yield(llm.StreamEvent{Type: llm.SETextDelta, Text: "partial"}, nil) {
+			return
+		}
+		if !yield(llm.StreamEvent{Type: llm.SEMessageDelta, Usage: llm.Usage{OutputTokens: 9, CacheWriteTokens: 4}}, nil) {
+			return
+		}
 		close(started)
 		<-ctx.Done()
 		yield(llm.StreamEvent{}, ctx.Err())


### PR DESCRIPTION
## 背景
`go vet ./agent` 报 `yield may be called again after returning false`(agent/capture_usage_test.go)。两个测试的 provider stream 连续调用 `yield` 而未检查返回值——迭代器协议要求 `yield` 返回 `false`(消费方已停止)后不得再调。

> 该修复原是在 PR #46 合并**之后**才推到分支的,没进 main,故单独开此 PR。

## 改动
每次 `yield(...)` 改为 `if !yield(...) { return }`,返回 false 即停止。测试语义不变(仍按序产出事件再产出错误/取消事件)。

## 验证
`go vet ./agent` 无 yield 告警;`go test ./agent`(编译)通过。