### PR TITLE
chore(deps): 升级 norma v0.3.1 → v0.3.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Autumn-27/artex
 go 1.26.3
 
 require (
-	github.com/Autumn-27/norma v0.3.1
+	github.com/Autumn-27/norma v0.3.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/lqqyt2423/go-mitmproxy v1.9.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Autumn-27/norma v0.3.1 h1:cSRojFJjivm4l3ck/KJXym7VyCnM1GLY7iq1pRYk4kk=
 github.com/Autumn-27/norma v0.3.1/go.mod h1:BudWrf7iHl96FgHqFr/HwN3mKYmGjJDt+xL2ZHXfFZw=
+github.com/Autumn-27/norma v0.3.2 h1:3gW84SbSrz8luW8kbi2tv3O7CLdRMQvyylCHj1QUdNk=
+github.com/Autumn-27/norma v0.3.2/go.mod h1:BudWrf7iHl96FgHqFr/HwN3mKYmGjJDt+xL2ZHXfFZw=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=


### PR DESCRIPTION
带入本轮 norma 修复：

- **reasoning/refusal 静默丢弃** — OpenAI Chat Completions 只认 `reasoning_content`，不认 vLLM/OpenRouter 的 `reasoning`，思考整轮丢失；拒答的 `refusal` 也没读。Responses 非流式补读 `reasoning_text`。
- **reasoning 三名去重** — `reasoning_content > reasoning > reasoning_text` 取第一个非空。
- **空响应(零内容块)有界重试** — 正常 stop 却解析出零块时，provider 内部重发，最多 2 次；max_tokens/取消/真错误不误伤。
- **压缩边界切断工具配对导致的网关 400** — `MessagesForAPI` 出口丢弃未配对工具块，修复 `role tool must follow tool_calls`，同时救回已烤进 transcript 的存量孤儿（原本会让意图永久 blocked）。

验证：norma 全套 + `-race` 全绿；ARTEX `go build ./...`、`go test ./agent ./llmrec ./server` 通过。

注意：目前为单元层验证，合并部署后仍需在 dev 环境 resume 一个已 blocked 的意图，确认 400 修复对存量坏 transcript 生效。