### PR TITLE
fix(llm): 配置列表返回 streaming 字段

### DIFF
--- a/server/dto.go
+++ b/server/dto.go
@@ -566,6 +566,9 @@ type LLMProfileDTO struct {
 	// pool_exclude=true 则不作为故障转移目标，但仍可被 agent/任务显式绑定。
 	Priority    int  `json:"priority"`
 	PoolExclude bool `json:"pool_exclude"`
+	// 收发模式：true=流式(SSE) | false=非流式。没有 omitempty —— false 必须出现在
+	// 响应里，否则前端读不到「非流式」，开关会回落成默认的流式。
+	Streaming bool `json:"streaming"`
 }
 
 func llmProfileDTO(p *db.LLMProfile) LLMProfileDTO {
@@ -585,6 +588,7 @@ func llmProfileDTO(p *db.LLMProfile) LLMProfileDTO {
 		IsDefault:       p.IsDefault,
 		Priority:        p.Priority,
 		PoolExclude:     p.PoolExclude,
+		Streaming:       p.Streaming,
 	}
 }
 


### PR DESCRIPTION
## 问题

前端把「流式输出」开关关掉、保存成功，重新打开 LLM 配置抽屉，开关又是打开的。

## 根因

`LLMProfileDTO`（`server/dto.go`）是手写字段映射，加 `streaming` 到 `db.LLMProfile` 时漏了同步到 DTO，于是配置列表接口的响应里压根没有 `streaming` 键。前端 `profile?.streaming ?? true` 读到 `undefined`，一律回落成默认的流式。

写入链路本身没问题，DB 里存的确实是 `false`，只是读不回来。

## 改动

- `LLMProfileDTO` 增加 `Streaming bool `json:"streaming"``，**不加 `omitempty`** —— 否则 `false` 会被省略，等于没修。
- `llmProfileDTO()` 补 `Streaming: p.Streaming`。

无 DB 变更，`streaming` 列与 `COALESCE(streaming,true)` 已存在。

## 验证

`go build ./...`、`go vet ./server/`、`go test ./server/` 均通过。

Closes #69