### PR TITLE
Fix possible fix(deps): 2 vulnerable dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
-	golang.org/x/mod v0.37.0 // indirect
+	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect


### PR DESCRIPTION
This changes `go.mod` to address something a scan flagged. It is around line 1.

The project depends on golang.org/x/mod v0.37.0, which is vulnerable to CVE-2026-56864. A compromised GOSUMDB can serve arbitrary module code that bypasses the module checksum database and transparency log, allowing an attacker to inject malicious code into the build process. Because this can lead to execution of arbitrary code in downstream applications, the risk is classified as HIGH.

Update golang.org/x/mod from v0.37.0 to v0.40.0 to resolve two high‑severity CVEs.

For reference: rule `CVE-2026-56864`. Rated high.

I may well be missing context here — if the current code is deliberate, feel free to close this.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
